### PR TITLE
force _fortify_level 2 to prevent F38 crashing

### DIFF
--- a/far2l.spec
+++ b/far2l.spec
@@ -1,6 +1,10 @@
 %global commit 5ee6a40bad3a6c4aafd9e13c3e7cbea19bad7cc1
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-
+%if 0%{?fedora} >= 38
+# Since F38 the build flags include D_FORTIFY_SOURCE=3 but this flag caused far2l to crash in some cases
+# https://fedoraproject.org/wiki/Changes/Add_FORTIFY_SOURCE=3_to_distribution_build_flags
+%define _fortify_level 2
+%endif
 %bcond_without gui
 %if %{with gui}
 Name: far2l
@@ -103,6 +107,9 @@ cmake -DUSEWX=no \
 %lang(ru) %{_mandir}/ru/man1/far2l.*
 
 %changelog
+* Sun Aug 13 2023 icesvz <icesvz@gmail.com> 2.5.1-beta
+- force _fortify_level 2 to prevent F38 crashing
+
 * Sat Jul 8 2023 Pavel Artsishevsky <polter.rnd@gmail.com> 2.5.1-beta
 - bump upstream commit (5ee6a40)
 

--- a/far2l.spec
+++ b/far2l.spec
@@ -1,10 +1,5 @@
-%global commit 5ee6a40bad3a6c4aafd9e13c3e7cbea19bad7cc1
+%global commit fe3da21891cf498194cf47202c1f246b0e66425e
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%if 0%{?fedora} >= 38
-# Since F38 the build flags include D_FORTIFY_SOURCE=3 but this flag caused far2l to crash in some cases
-# https://fedoraproject.org/wiki/Changes/Add_FORTIFY_SOURCE=3_to_distribution_build_flags
-%define _fortify_level 2
-%endif
 %bcond_without gui
 %if %{with gui}
 Name: far2l
@@ -107,6 +102,9 @@ cmake -DUSEWX=no \
 %lang(ru) %{_mandir}/ru/man1/far2l.*
 
 %changelog
+* Mon Aug 14 2023 icesvz <icesvz@gmail.com> 2.5.1-beta
+- bump upstream commit (fe3da21)
+
 * Sun Aug 13 2023 icesvz <icesvz@gmail.com> 2.5.1-beta
 - force _fortify_level 2 to prevent F38 crashing
 


### PR DESCRIPTION
Far2l crashes on Fedora 38 in some cases (when creating new site connection in netrocks plugin, when working in command line).  
This happens because in F38 the build flags include D_FORTIFY_SOURCE=3  https://fedoraproject.org/wiki/Changes/Add_FORTIFY_SOURCE=3_to_distribution_build_flags 

The test build availible https://copr.fedorainfracloud.org/coprs/icesvz/far2l_f38/ 
